### PR TITLE
Enable compilation with current Castro version

### DIFF
--- a/Prob_nd.F90
+++ b/Prob_nd.F90
@@ -8,7 +8,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_fort_module, only: rt => amrex_real
   use eos_module
   use eos_type_module
-  use parallel, only: parallel_IOProcessor
+  use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
   use prob_params_module, only: center
   use interpolate_module, only: locate
   use model_interp_module, only: interp1d_linear
@@ -17,7 +17,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   implicit none
   integer :: init, namlen
   integer :: name(namlen)
-  real (rt) :: problo(2), probhi(2)
+  real (rt) :: problo(3), probhi(3)
 
   integer :: untin,i,j,k,dir
   real (rt) :: probhi_r, rcyl, zcyl, r, dr, dvol, volr, dvolr, gr
@@ -186,7 +186,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   end if
   call interp1d_linear( i, imax_chim, volx_c_chim, gravx_c_avg_chim, volr, gr )
 
-  if (parallel_IOProcessor()) then
+  if (amrex_pd_ioprocessor()) then
     write(*,'(a,2es23.15)') 'average g(r) (chimera)        =',r,gr
 
     write(*,'(a,2es23.15)') 'total mass   (chimera, star)  =',mass_chim,mass_star
@@ -226,7 +226,7 @@ end subroutine amrex_probinit
 ! ::: -----------------------------------------------------------
 
 subroutine ca_initdata(level,time,lo,hi,nscal, &
-                       state,state_l1,state_l2,state_h1,state_h2, &
+                       state, state_lo, state_hi, &
                        delta,xlo,xhi)
 
   use amrex_error_module
@@ -245,10 +245,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   implicit none
 
   integer :: level, nscal
-  integer :: lo(2), hi(2)
-  integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  integer :: lo(3), hi(3)
+  integer :: state_lo(3), state_hi(3)
+  double precision :: xlo(3), xhi(3), time, delta(3)
+  double precision :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),NVAR)
 
   ! local variables
   real (rt) :: xcen(lo(1):hi(1))

--- a/inputs.2d.D15-MESA-SF0.8
+++ b/inputs.2d.D15-MESA-SF0.8
@@ -34,10 +34,10 @@ castro.point_mass = 0.0 #-2.878606188e+32
 castro.point_mass_fix_solution = 1
 
 # REACTIONS
-castro.react_T_max = 6.0d9
-castro.react_T_min = 1.0d8
-castro.dtnuc_X = 1.0d-4
-castro.dtnuc_e = 1.0d-2
+castro.react_T_max = 6.0e9
+castro.react_T_min = 1.0e8
+castro.dtnuc_X = 1.0e-4
+castro.dtnuc_e = 1.0e-2
 
 # HYDRO
 castro.ppm_type = 1

--- a/probin.2d.D15-MESA-SF0.8
+++ b/probin.2d.D15-MESA-SF0.8
@@ -1,7 +1,7 @@
 &fortin
 
   chimera_fname =  "/Users/austin/Documents/research/chimera/D15-MESA-SF0.8/chimera_07581_grid_1_01.h5"
-  mesa_fname = "s15_0.8_mesa.d"
+  star_fname = "s15_0.8_mesa.d"
 
   ! flag for interpolation method (1=linear, 2=spline)
   interp_method = 1
@@ -9,9 +9,9 @@
   ! flag for eos_input (1=rt,2=rh,3=tp,4=rp,5=re,6=ps,7=ph,8=th)
   eos_input = 1
 
-! max_radius = 3.36975099878105d9
+  max_radius = 3.36975099878105d9
 
-  min_radius = 0.0d0
+ ! min_radius = 0.0d0
   rho_inner = 1.0d-5
 
   use_quad = .true.


### PR DESCRIPTION
These changes fix minor runtime issues and enable compilation with the current version of Castro on the `ecp/two-moment` branch.

The largest change is the problem initialization subroutines. Castro has moved to supporting only dimension agnostic problems. In this style, instead of passing lo and hi array indices for every dimension separately, we always treat FAB data as if it were 3D regardless the dimensionality, and we pass 0 for the lo and hi of unused dimensions.

This allows us to loop over the 3D array indices as in an actual 3D problem with no adverse consequences in 1D and 2D, so we can maintain fewer lines of code.

This PR replaces the 2D problem initialization with a `Prob_nd.F90` source file that only currently supports 2D.

Future development can add 1D and 3D support to the `Prob_nd.F90` source file. If different logic is necessary for each case, it is possible to check the preprocessor variable `AMREX_SPACEDIM` like:

```
#if (AMREX_SPACEDIM == 1)
...
#elif (AMREX_SPACEDIM == 2)
...
#elif (AMREX_SPACEDIM == 3)
...
#endif
```